### PR TITLE
Remove Windows builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # TODO: Add windows-latest
         os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9]
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 ## My Project
 
+Currently, braket algorithms are tested on Linux and Max. We recommend using Linux or Max because the certain electronic structure packages are only compatible on these platforms.
+
 TODO: Fill this README out!
 
 Be sure to:
 
-* Change the title in this README
-* Edit your repository description on GitHub
+- Change the title in this README
+- Edit your repository description on GitHub
 
 ## Security
 
@@ -14,4 +16,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This project is licensed under the Apache-2.0 License.
-


### PR DESCRIPTION
Some dependencies don't work on Windows. Specifically, QMC depends on pyscf, openfermion, which may not support Windows consistently. 


<del>Also, might as well test latest python 3.10 and 3.11 builds too. 
</del>nvm. oppy doesn't like 3.11