### PR TITLE
fix: correct typo 'am' to 'an' in Quantum_Fourier_Transform.ipynb

### DIFF
--- a/notebooks/textbook/Quantum_Fourier_Transform.ipynb
+++ b/notebooks/textbook/Quantum_Fourier_Transform.ipynb
@@ -114,7 +114,7 @@
    "id": "6ec6c365",
    "metadata": {},
    "source": [
-    "You can use methods `qft()` and `iqft()` to append quantum Fourier Transform circuits to am existing circuit. "
+    "You can use methods `qft()` and `iqft()` to append quantum Fourier Transform circuits to an existing circuit. "
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes a minor typo where "am" was incorrectly used instead of "an" in [file/line].
Let me know if any adjustments are needed. Thank you!

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
