### PR TITLE
Support N=33 in Shor's algorithm

### DIFF
--- a/notebooks/textbook/Shors_Algorithm.ipynb
+++ b/notebooks/textbook/Shors_Algorithm.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "N = 15  # Integer to factor (currently 15, 21, 35 work)\n",
+    "N = 15  # Integer to factor (currently 15, 21, 33, 35 work)\n",
     "a = 7  # Any integer that satisfies 1 < a < N and gcd(a, N) = 1.\n",
     "\n",
     "\n",

--- a/src/braket/experimental/algorithms/shors/shors.py
+++ b/src/braket/experimental/algorithms/shors/shors.py
@@ -60,7 +60,10 @@ def shors_algorithm(integer_N: int, integer_a: int) -> Circuit:
     shors_circuit.x(aux_qubits[0])
 
     # Apply modular exponentiation
-    shors_circuit.modular_exponentiation_amod15(counting_qubits, aux_qubits, integer_a)
+    if integer_N == 33:
+        shors_circuit.modular_exponentiation_amod33(counting_qubits, aux_qubits, integer_a)
+    else:
+        shors_circuit.modular_exponentiation_amod15(counting_qubits, aux_qubits, integer_a)
 
     # Apply inverse QFT
     shors_circuit.inverse_qft_noswaps(counting_qubits)
@@ -177,6 +180,41 @@ def modular_exponentiation_amod15(
                     mod_exp_amod15.cnot(x, q)
 
     return mod_exp_amod15
+
+
+@circuit.subroutine(register=True)
+def modular_exponentiation_amod33(
+    counting_qubits: QubitSetInput, aux_qubits: QubitSetInput, integer_a: int
+) -> Circuit:
+    """
+    Construct a circuit object corresponding the modular exponentiation of a^x Mod 33
+
+    Args:
+        counting_qubits (QubitSetInput): Qubits defining the counting register
+        aux_qubits (QubitSetInput) : Qubits defining the auxilary register
+        integer_a (int) : Any integer that satisfies 1 < a < N and gcd(a, N) = 1.
+    Returns:
+        Circuit: Circuit object that implements the modular exponentiation of a^x Mod 33
+    """
+
+    # Instantiate circuit object
+    mod_exp_amod33 = Circuit()
+
+    for x in counting_qubits:
+        r = 2**x
+        if integer_a not in [10, 23]:
+            raise ValueError("integer 'a' must be 10 or 23 for N = 33")
+        for iteration in range(r):
+            if integer_a == 10:
+                mod_exp_amod33.cnot(x, aux_qubits[0])
+                mod_exp_amod33.cnot(x, aux_qubits[1])  
+                mod_exp_amod33.cnot(x, aux_qubits[3])  
+            if integer_a == 23:
+                mod_exp_amod33.cnot(x, aux_qubits[1])
+                mod_exp_amod33.cnot(x, aux_qubits[2])  
+                mod_exp_amod33.cnot(x, aux_qubits[4])        
+
+    return mod_exp_amod33
 
 
 def get_factors_from_results(

--- a/test/unit_tests/braket/experimental/algorithms/shors/test_shors.py
+++ b/test/unit_tests/braket/experimental/algorithms/shors/test_shors.py
@@ -50,6 +50,16 @@ def test_shors_algorithm():
     assert aggregate_results["guessed_factors"] == {3, 5}
 
 
+def test_shors_algorithm_for_33():
+    integer_N = 33
+    integer_a = 10
+    shor = shors_algorithm(integer_N, integer_a)
+    local_simulator = LocalSimulator()
+    output = run_shors_algorithm(shor, local_simulator)
+    aggregate_results = get_factors_from_results(output, integer_N, integer_a, False)
+    assert aggregate_results["guessed_factors"] == {3, 11}
+
+
 def test_all_valid_a():
     local_simulator = LocalSimulator()
     integer_N = 15
@@ -58,6 +68,16 @@ def test_all_valid_a():
         output = run_shors_algorithm(shor, local_simulator)
         aggregate_results = get_factors_from_results(output, integer_N, integer_a, True)
         assert aggregate_results["guessed_factors"] == {3, 5}
+
+
+def test_all_valid_a_for_33():
+    local_simulator = LocalSimulator()
+    integer_N = 33
+    for integer_a in [10, 23]:
+        shor = shors_algorithm(integer_N, integer_a)
+        output = run_shors_algorithm(shor, local_simulator)
+        aggregate_results = get_factors_from_results(output, integer_N, integer_a, True)
+        assert aggregate_results["guessed_factors"] == {3, 11}
 
 
 def test_no_counts():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds support for modular exponentiation circuits for `N = 33` in Shor's algorithm. 
Specifically:

- A new subroutine `modular_exponentiation_amod33()` is added.

- `shors_algorithm()` now calls `modular_exponentiation_amod33()` when `N == 33`.

Although the current implementation does not appear to produce the expected nontrivial factors (i.e., 3 and 11) in practice, these additions allow users to run meaningful Shor factorization examples with `N = 33`.


*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-algorithm-library/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
